### PR TITLE
Change itemtank recipe to use `forge:chests` tag.

### DIFF
--- a/src/main/resources/data/pedestals/recipes/upgrades/itemtank.json
+++ b/src/main/resources/data/pedestals/recipes/upgrades/itemtank.json
@@ -5,7 +5,7 @@
       "item": "pedestals:coin/default"
     },
     {
-      "item": "minecraft:chest"
+      "tag": "forge:chests"
     }
   ],
   "result": {


### PR DESCRIPTION
Makes the Item Tank upgrade slightly friendlier when used with Quark's unique wooden chest types.

But please do ensure this does what you want. It seemed to work right on KubeJS, but I can't build your mod. :)