### PR TITLE
Refactoring of the pedestal internal inventory.

### DIFF
--- a/src/main/java/com/mowmaster/pedestals/Items/Augments/AugmentTieredCapacity.java
+++ b/src/main/java/com/mowmaster/pedestals/Items/Augments/AugmentTieredCapacity.java
@@ -5,8 +5,6 @@ import com.mowmaster.pedestals.Configs.PedestalConfig;
 import com.mowmaster.pedestals.Registry.DeferredRegisterItems;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
@@ -25,52 +23,52 @@ public class AugmentTieredCapacity extends AugmentBase{
         super(p_41383_);
     }
 
-    public int getAdditionalItemTransferRatePerItem(Item augment)
+    public static int getAdditionalItemTransferRatePerItem(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_CAPACITY.get()))return PedestalConfig.COMMON.augment_t1CapacityItem.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_CAPACITY.get()))return PedestalConfig.COMMON.augment_t2CapacityItem.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_CAPACITY.get()))return PedestalConfig.COMMON.augment_t3CapacityItem.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_CAPACITY.get()))return PedestalConfig.COMMON.augment_t4CapacityItem.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_CAPACITY.get())) return PedestalConfig.COMMON.augment_t1CapacityItem.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_CAPACITY.get())) return PedestalConfig.COMMON.augment_t2CapacityItem.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_CAPACITY.get())) return PedestalConfig.COMMON.augment_t3CapacityItem.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_CAPACITY.get())) return PedestalConfig.COMMON.augment_t4CapacityItem.get();
         return 0;
     }
-    public int getAdditionalFluidTransferRatePerItem(Item augment)
+    public static int getAdditionalFluidTransferRatePerItem(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_CAPACITY.get()))return PedestalConfig.COMMON.augment_t1CapacityFluid.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_CAPACITY.get()))return PedestalConfig.COMMON.augment_t2CapacityFluid.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_CAPACITY.get()))return PedestalConfig.COMMON.augment_t3CapacityFluid.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_CAPACITY.get()))return PedestalConfig.COMMON.augment_t4CapacityFluid.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_CAPACITY.get())) return PedestalConfig.COMMON.augment_t1CapacityFluid.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_CAPACITY.get())) return PedestalConfig.COMMON.augment_t2CapacityFluid.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_CAPACITY.get())) return PedestalConfig.COMMON.augment_t3CapacityFluid.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_CAPACITY.get())) return PedestalConfig.COMMON.augment_t4CapacityFluid.get();
         return 0;
     }
-    public int getAdditionalEnergyTransferRatePerItem(Item augment)
+    public static int getAdditionalEnergyTransferRatePerItem(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_CAPACITY.get()))return PedestalConfig.COMMON.augment_t1CapacityEnergy.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_CAPACITY.get()))return PedestalConfig.COMMON.augment_t2CapacityEnergy.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_CAPACITY.get()))return PedestalConfig.COMMON.augment_t3CapacityEnergy.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_CAPACITY.get()))return PedestalConfig.COMMON.augment_t4CapacityEnergy.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_CAPACITY.get())) return PedestalConfig.COMMON.augment_t1CapacityEnergy.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_CAPACITY.get())) return PedestalConfig.COMMON.augment_t2CapacityEnergy.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_CAPACITY.get())) return PedestalConfig.COMMON.augment_t3CapacityEnergy.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_CAPACITY.get())) return PedestalConfig.COMMON.augment_t4CapacityEnergy.get();
         return 0;
     }
-    public int getAdditionalXpTransferRatePerItem(Item augment)
+    public static int getAdditionalXpTransferRatePerItem(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_CAPACITY.get()))return PedestalConfig.COMMON.augment_t1CapacityXp.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_CAPACITY.get()))return PedestalConfig.COMMON.augment_t2CapacityXp.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_CAPACITY.get()))return PedestalConfig.COMMON.augment_t3CapacityXp.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_CAPACITY.get()))return PedestalConfig.COMMON.augment_t4CapacityXp.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_CAPACITY.get())) return PedestalConfig.COMMON.augment_t1CapacityXp.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_CAPACITY.get())) return PedestalConfig.COMMON.augment_t2CapacityXp.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_CAPACITY.get())) return PedestalConfig.COMMON.augment_t3CapacityXp.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_CAPACITY.get())) return PedestalConfig.COMMON.augment_t4CapacityXp.get();
         return 0;
     }
-    public int getAdditionalDustTransferRatePerItem(Item augment)
+    public static int getAdditionalDustTransferRatePerItem(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_CAPACITY.get()))return PedestalConfig.COMMON.augment_t1CapacityDust.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_CAPACITY.get()))return PedestalConfig.COMMON.augment_t2CapacityDust.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_CAPACITY.get()))return PedestalConfig.COMMON.augment_t3CapacityDust.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_CAPACITY.get()))return PedestalConfig.COMMON.augment_t4CapacityDust.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_CAPACITY.get())) return PedestalConfig.COMMON.augment_t1CapacityDust.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_CAPACITY.get())) return PedestalConfig.COMMON.augment_t2CapacityDust.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_CAPACITY.get())) return PedestalConfig.COMMON.augment_t3CapacityDust.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_CAPACITY.get())) return PedestalConfig.COMMON.augment_t4CapacityDust.get();
         return 0;
     }
-    public int getAllowedInsertAmount(Item augment)
+    public static int getAllowedInsertAmount(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_CAPACITY.get()))return PedestalConfig.COMMON.augment_t1CapacityInsertSize.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_CAPACITY.get()))return PedestalConfig.COMMON.augment_t2CapacityInsertSize.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_CAPACITY.get()))return PedestalConfig.COMMON.augment_t3CapacityInsertSize.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_CAPACITY.get()))return PedestalConfig.COMMON.augment_t4CapacityInsertSize.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_CAPACITY.get())) return PedestalConfig.COMMON.augment_t1CapacityInsertSize.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_CAPACITY.get())) return PedestalConfig.COMMON.augment_t2CapacityInsertSize.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_CAPACITY.get())) return PedestalConfig.COMMON.augment_t3CapacityInsertSize.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_CAPACITY.get())) return PedestalConfig.COMMON.augment_t4CapacityInsertSize.get();
         return 0;
     }
 
@@ -78,44 +76,39 @@ public class AugmentTieredCapacity extends AugmentBase{
     public void appendHoverText(ItemStack p_41421_, @Nullable Level p_41422_, List<Component> p_41423_, TooltipFlag p_41424_) {
         super.appendHoverText(p_41421_, p_41422_, p_41423_, p_41424_);
 
-        if(p_41421_.getItem() instanceof AugmentTieredCapacity capacityAugment)
-        {
-            List<String> listed = new ArrayList<>();
-            List<ChatFormatting> colors = new ArrayList<>();
+        List<String> listed = new ArrayList<>();
+        List<ChatFormatting> colors = new ArrayList<>();
 
-            colors.add(ChatFormatting.YELLOW);
-            listed.add(MODID + ".augments_capacity_itemrate");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+capacityAugment.getAdditionalItemTransferRatePerItem(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.YELLOW);
+        listed.add(MODID + ".augments_capacity_itemrate");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredCapacity.getAdditionalItemTransferRatePerItem(p_41421_)));
 
-            colors.add(ChatFormatting.AQUA);
-            listed.add(MODID + ".augments_capacity_fluidrate");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+capacityAugment.getAdditionalFluidTransferRatePerItem(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.AQUA);
+        listed.add(MODID + ".augments_capacity_fluidrate");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredCapacity.getAdditionalFluidTransferRatePerItem(p_41421_)));
 
-            colors.add(ChatFormatting.RED);
-            listed.add(MODID + ".augments_capacity_energyrate");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+capacityAugment.getAdditionalEnergyTransferRatePerItem(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.RED);
+        listed.add(MODID + ".augments_capacity_energyrate");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredCapacity.getAdditionalEnergyTransferRatePerItem(p_41421_)));
 
-            colors.add(ChatFormatting.GREEN);
-            listed.add(MODID + ".augments_capacity_xprate");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+capacityAugment.getAdditionalXpTransferRatePerItem(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.GREEN);
+        listed.add(MODID + ".augments_capacity_xprate");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredCapacity.getAdditionalXpTransferRatePerItem(p_41421_)));
 
-            colors.add(ChatFormatting.LIGHT_PURPLE);
-            listed.add(MODID + ".augments_capacity_dustrate");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+capacityAugment.getAdditionalDustTransferRatePerItem(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.LIGHT_PURPLE);
+        listed.add(MODID + ".augments_capacity_dustrate");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredCapacity.getAdditionalDustTransferRatePerItem(p_41421_)));
 
-            colors.add(ChatFormatting.GOLD);
-            listed.add(MODID + ".augments_insertable");
-            colors.add(ChatFormatting.GOLD);
-            listed.add(""+capacityAugment.getAllowedInsertAmount(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.GOLD);
+        listed.add(MODID + ".augments_insertable");
+        colors.add(ChatFormatting.GOLD);
+        listed.add(String.valueOf(AugmentTieredCapacity.getAllowedInsertAmount(p_41421_)));
 
-            MowLibTooltipUtils.addTooltipShiftMessageMultiWithStyle(MODID+".augments",p_41423_,listed,colors);
-        }
+        MowLibTooltipUtils.addTooltipShiftMessageMultiWithStyle(MODID+".augments",p_41423_,listed,colors);
     }
-
-
 }

--- a/src/main/java/com/mowmaster/pedestals/Items/Augments/AugmentTieredRange.java
+++ b/src/main/java/com/mowmaster/pedestals/Items/Augments/AugmentTieredRange.java
@@ -5,7 +5,6 @@ import com.mowmaster.pedestals.Configs.PedestalConfig;
 import com.mowmaster.pedestals.Registry.DeferredRegisterItems;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
@@ -20,26 +19,25 @@ import net.minecraft.world.item.Item.Properties;
 
 public class AugmentTieredRange extends AugmentBase{
 
-
     public AugmentTieredRange(Properties p_41383_) {
         super(p_41383_);
     }
 
-    public int getRangeIncreasePerItem(Item augment)
+    public static int getRangeIncreasePerItem(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_RANGE.get()))return PedestalConfig.COMMON.augment_t1RangeIncrease.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_RANGE.get()))return PedestalConfig.COMMON.augment_t2RangeIncrease.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_RANGE.get()))return PedestalConfig.COMMON.augment_t3RangeIncrease.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_RANGE.get()))return PedestalConfig.COMMON.augment_t4RangeIncrease.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_RANGE.get())) return PedestalConfig.COMMON.augment_t1RangeIncrease.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_RANGE.get())) return PedestalConfig.COMMON.augment_t2RangeIncrease.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_RANGE.get())) return PedestalConfig.COMMON.augment_t3RangeIncrease.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_RANGE.get())) return PedestalConfig.COMMON.augment_t4RangeIncrease.get();
         return 0;
     }
 
-    public int getAllowedInsertAmount(Item augment)
+    public static int getAllowedInsertAmount(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_RANGE.get()))return PedestalConfig.COMMON.augment_t1RangeInsertable.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_RANGE.get()))return PedestalConfig.COMMON.augment_t2RangeInsertable.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_RANGE.get()))return PedestalConfig.COMMON.augment_t3RangeInsertable.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_RANGE.get()))return PedestalConfig.COMMON.augment_t4RangeInsertable.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_RANGE.get())) return PedestalConfig.COMMON.augment_t1RangeInsertable.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_RANGE.get())) return PedestalConfig.COMMON.augment_t2RangeInsertable.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_RANGE.get())) return PedestalConfig.COMMON.augment_t3RangeInsertable.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_RANGE.get())) return PedestalConfig.COMMON.augment_t4RangeInsertable.get();
         return 0;
     }
 
@@ -47,23 +45,19 @@ public class AugmentTieredRange extends AugmentBase{
     public void appendHoverText(ItemStack p_41421_, @Nullable Level p_41422_, List<Component> p_41423_, TooltipFlag p_41424_) {
         super.appendHoverText(p_41421_, p_41422_, p_41423_, p_41424_);
 
-        if(p_41421_.getItem() instanceof AugmentTieredRange rangeAugment)
-        {
-            List<String> listed = new ArrayList<>();
-            List<ChatFormatting> colors = new ArrayList<>();
+        List<String> listed = new ArrayList<>();
+        List<ChatFormatting> colors = new ArrayList<>();
 
-            colors.add(ChatFormatting.YELLOW);
-            listed.add(MODID + ".augments_range_increase");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+rangeAugment.getRangeIncreasePerItem(p_41421_.getItem())+"");
-            colors.add(ChatFormatting.LIGHT_PURPLE);
-            listed.add(MODID + ".augments_insertable");
-            colors.add(ChatFormatting.GOLD);
-            listed.add(""+rangeAugment.getAllowedInsertAmount(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.YELLOW);
+        listed.add(MODID + ".augments_range_increase");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredRange.getRangeIncreasePerItem(p_41421_)));
+        colors.add(ChatFormatting.LIGHT_PURPLE);
+        listed.add(MODID + ".augments_insertable");
+        colors.add(ChatFormatting.GOLD);
+        listed.add(String.valueOf(AugmentTieredRange.getAllowedInsertAmount(p_41421_)));
 
-
-            MowLibTooltipUtils.addTooltipShiftMessageMultiWithStyle(MODID,p_41423_,listed,colors);
-        }
+        MowLibTooltipUtils.addTooltipShiftMessageMultiWithStyle(MODID,p_41423_,listed,colors);
     }
 
 

--- a/src/main/java/com/mowmaster/pedestals/Items/Augments/AugmentTieredSpeed.java
+++ b/src/main/java/com/mowmaster/pedestals/Items/Augments/AugmentTieredSpeed.java
@@ -5,7 +5,6 @@ import com.mowmaster.pedestals.Configs.PedestalConfig;
 import com.mowmaster.pedestals.Registry.DeferredRegisterItems;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
@@ -16,29 +15,27 @@ import java.util.List;
 
 import static com.mowmaster.pedestals.PedestalUtils.References.MODID;
 
-import net.minecraft.world.item.Item.Properties;
-
 public class AugmentTieredSpeed extends AugmentBase{
 
     public AugmentTieredSpeed(Properties p_41383_) {
         super(p_41383_);
     }
 
-    public int getTicksReducedPerItem(Item augment)
+    public static int getTicksReduced(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_SPEED.get()))return PedestalConfig.COMMON.augment_t1SpeedReduction.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_SPEED.get()))return PedestalConfig.COMMON.augment_t2SpeedReduction.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_SPEED.get()))return PedestalConfig.COMMON.augment_t3SpeedReduction.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_SPEED.get()))return PedestalConfig.COMMON.augment_t4SpeedReduction.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_SPEED.get())) return PedestalConfig.COMMON.augment_t1SpeedReduction.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_SPEED.get())) return PedestalConfig.COMMON.augment_t2SpeedReduction.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_SPEED.get())) return PedestalConfig.COMMON.augment_t3SpeedReduction.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_SPEED.get())) return PedestalConfig.COMMON.augment_t4SpeedReduction.get();
         return 0;
     }
 
-    public int getAllowedInsertAmount(Item augment)
+    public static int getAllowedInsertAmount(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_SPEED.get()))return PedestalConfig.COMMON.augment_t1SpeedInsertable.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_SPEED.get()))return PedestalConfig.COMMON.augment_t2SpeedInsertable.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_SPEED.get()))return PedestalConfig.COMMON.augment_t3SpeedInsertable.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_SPEED.get()))return PedestalConfig.COMMON.augment_t4SpeedInsertable.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_SPEED.get())) return PedestalConfig.COMMON.augment_t1SpeedInsertable.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_SPEED.get())) return PedestalConfig.COMMON.augment_t2SpeedInsertable.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_SPEED.get())) return PedestalConfig.COMMON.augment_t3SpeedInsertable.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_SPEED.get())) return PedestalConfig.COMMON.augment_t4SpeedInsertable.get();
         return 0;
     }
 
@@ -46,24 +43,20 @@ public class AugmentTieredSpeed extends AugmentBase{
     public void appendHoverText(ItemStack p_41421_, @Nullable Level p_41422_, List<Component> p_41423_, TooltipFlag p_41424_) {
         super.appendHoverText(p_41421_, p_41422_, p_41423_, p_41424_);
 
-        if(p_41421_.getItem() instanceof AugmentTieredSpeed speedAugment)
-        {
-            List<String> listed = new ArrayList<>();
-            List<ChatFormatting> colors = new ArrayList<>();
+        List<String> listed = new ArrayList<>();
+        List<ChatFormatting> colors = new ArrayList<>();
 
-            colors.add(ChatFormatting.YELLOW);
-            listed.add(MODID + ".augments_speed_ticksreduced");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+speedAugment.getTicksReducedPerItem(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.YELLOW);
+        listed.add(MODID + ".augments_speed_ticksreduced");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredSpeed.getTicksReduced(p_41421_)));
 
-            colors.add(ChatFormatting.LIGHT_PURPLE);
-            listed.add(MODID + ".augments_insertable");
-            colors.add(ChatFormatting.GOLD);
-            listed.add(""+speedAugment.getAllowedInsertAmount(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.LIGHT_PURPLE);
+        listed.add(MODID + ".augments_insertable");
+        colors.add(ChatFormatting.GOLD);
+        listed.add(String.valueOf(AugmentTieredSpeed.getAllowedInsertAmount(p_41421_)));
 
-
-            MowLibTooltipUtils.addTooltipShiftMessageMultiWithStyle(MODID,p_41423_,listed,colors);
-        }
+        MowLibTooltipUtils.addTooltipShiftMessageMultiWithStyle(MODID,p_41423_,listed,colors);
     }
 
 

--- a/src/main/java/com/mowmaster/pedestals/Items/Augments/AugmentTieredStorage.java
+++ b/src/main/java/com/mowmaster/pedestals/Items/Augments/AugmentTieredStorage.java
@@ -5,7 +5,6 @@ import com.mowmaster.pedestals.Configs.PedestalConfig;
 import com.mowmaster.pedestals.Registry.DeferredRegisterItems;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
@@ -20,58 +19,57 @@ import net.minecraft.world.item.Item.Properties;
 
 public class AugmentTieredStorage extends AugmentBase{
 
-
     public AugmentTieredStorage(Properties p_41383_) {
         super(p_41383_);
     }
 
-    public int getAdditionalItemStoragePerItem(Item augment)
+    public static int getAdditionalItemStoragePerItem(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_STORAGE.get()))return PedestalConfig.COMMON.augment_t1StorageItem.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_STORAGE.get()))return PedestalConfig.COMMON.augment_t2StorageItem.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_STORAGE.get()))return PedestalConfig.COMMON.augment_t3StorageItem.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_STORAGE.get()))return PedestalConfig.COMMON.augment_t4StorageItem.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_STORAGE.get())) return PedestalConfig.COMMON.augment_t1StorageItem.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_STORAGE.get())) return PedestalConfig.COMMON.augment_t2StorageItem.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_STORAGE.get())) return PedestalConfig.COMMON.augment_t3StorageItem.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_STORAGE.get())) return PedestalConfig.COMMON.augment_t4StorageItem.get();
         return 0;
     }
-    public int getAdditionalFluidStoragePerItem(Item augment)
+    public static int getAdditionalFluidStoragePerItem(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_STORAGE.get()))return PedestalConfig.COMMON.augment_t1StorageFluid.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_STORAGE.get()))return PedestalConfig.COMMON.augment_t2StorageFluid.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_STORAGE.get()))return PedestalConfig.COMMON.augment_t3StorageFluid.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_STORAGE.get()))return PedestalConfig.COMMON.augment_t4StorageFluid.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_STORAGE.get())) return PedestalConfig.COMMON.augment_t1StorageFluid.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_STORAGE.get())) return PedestalConfig.COMMON.augment_t2StorageFluid.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_STORAGE.get())) return PedestalConfig.COMMON.augment_t3StorageFluid.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_STORAGE.get())) return PedestalConfig.COMMON.augment_t4StorageFluid.get();
         return 0;
     }
-    public int getAdditionalEnergyStoragePerItem(Item augment)
+    public static int getAdditionalEnergyStoragePerItem(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_STORAGE.get()))return PedestalConfig.COMMON.augment_t1StorageEnergy.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_STORAGE.get()))return PedestalConfig.COMMON.augment_t2StorageEnergy.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_STORAGE.get()))return PedestalConfig.COMMON.augment_t3StorageEnergy.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_STORAGE.get()))return PedestalConfig.COMMON.augment_t4StorageEnergy.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_STORAGE.get())) return PedestalConfig.COMMON.augment_t1StorageEnergy.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_STORAGE.get())) return PedestalConfig.COMMON.augment_t2StorageEnergy.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_STORAGE.get())) return PedestalConfig.COMMON.augment_t3StorageEnergy.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_STORAGE.get())) return PedestalConfig.COMMON.augment_t4StorageEnergy.get();
         return 0;
     }
-    public int getAdditionalXpStoragePerItem(Item augment)
+    public static int getAdditionalXpStoragePerItem(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_STORAGE.get()))return PedestalConfig.COMMON.augment_t1StorageXp.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_STORAGE.get()))return PedestalConfig.COMMON.augment_t2StorageXp.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_STORAGE.get()))return PedestalConfig.COMMON.augment_t3StorageXp.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_STORAGE.get()))return PedestalConfig.COMMON.augment_t4StorageXp.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_STORAGE.get())) return PedestalConfig.COMMON.augment_t1StorageXp.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_STORAGE.get())) return PedestalConfig.COMMON.augment_t2StorageXp.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_STORAGE.get())) return PedestalConfig.COMMON.augment_t3StorageXp.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_STORAGE.get())) return PedestalConfig.COMMON.augment_t4StorageXp.get();
         return 0;
     }
-    public int getAdditionalDustStoragePerItem(Item augment)
+    public static int getAdditionalDustStoragePerItem(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_STORAGE.get()))return PedestalConfig.COMMON.augment_t1StorageDust.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_STORAGE.get()))return PedestalConfig.COMMON.augment_t2StorageDust.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_STORAGE.get()))return PedestalConfig.COMMON.augment_t3StorageDust.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_STORAGE.get()))return PedestalConfig.COMMON.augment_t4StorageDust.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_STORAGE.get())) return PedestalConfig.COMMON.augment_t1StorageDust.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_STORAGE.get())) return PedestalConfig.COMMON.augment_t2StorageDust.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_STORAGE.get())) return PedestalConfig.COMMON.augment_t3StorageDust.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_STORAGE.get())) return PedestalConfig.COMMON.augment_t4StorageDust.get();
         return 0;
     }
 
-    public int getAllowedInsertAmount(Item augment)
+    public static int getAllowedInsertAmount(ItemStack stack)
     {
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_STORAGE.get()))return PedestalConfig.COMMON.augment_t1StorageInsertSize.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_STORAGE.get()))return PedestalConfig.COMMON.augment_t2StorageInsertSize.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_STORAGE.get()))return PedestalConfig.COMMON.augment_t3StorageInsertSize.get();
-        if(augment.equals(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_STORAGE.get()))return PedestalConfig.COMMON.augment_t4StorageInsertSize.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T1_STORAGE.get())) return PedestalConfig.COMMON.augment_t1StorageInsertSize.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T2_STORAGE.get())) return PedestalConfig.COMMON.augment_t2StorageInsertSize.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T3_STORAGE.get())) return PedestalConfig.COMMON.augment_t3StorageInsertSize.get();
+        if(stack.is(DeferredRegisterItems.AUGMENT_PEDESTAL_T4_STORAGE.get())) return PedestalConfig.COMMON.augment_t4StorageInsertSize.get();
         return 0;
     }
 
@@ -79,44 +77,40 @@ public class AugmentTieredStorage extends AugmentBase{
     public void appendHoverText(ItemStack p_41421_, @Nullable Level p_41422_, List<Component> p_41423_, TooltipFlag p_41424_) {
         super.appendHoverText(p_41421_, p_41422_, p_41423_, p_41424_);
 
-        if(p_41421_.getItem() instanceof AugmentTieredStorage storageAugment)
-        {
-            List<String> listed = new ArrayList<>();
-            List<ChatFormatting> colors = new ArrayList<>();
+        List<String> listed = new ArrayList<>();
+        List<ChatFormatting> colors = new ArrayList<>();
 
-            colors.add(ChatFormatting.YELLOW);
-            listed.add(MODID + ".augments_storage_itemrate");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+storageAugment.getAdditionalItemStoragePerItem(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.YELLOW);
+        listed.add(MODID + ".augments_storage_itemrate");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredStorage.getAdditionalItemStoragePerItem(p_41421_)));
 
-            colors.add(ChatFormatting.AQUA);
-            listed.add(MODID + ".augments_storage_fluidrate");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+storageAugment.getAdditionalFluidStoragePerItem(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.AQUA);
+        listed.add(MODID + ".augments_storage_fluidrate");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredStorage.getAdditionalFluidStoragePerItem(p_41421_)));
 
-            colors.add(ChatFormatting.RED);
-            listed.add(MODID + ".augments_storage_energyrate");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+storageAugment.getAdditionalEnergyStoragePerItem(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.RED);
+        listed.add(MODID + ".augments_storage_energyrate");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredStorage.getAdditionalEnergyStoragePerItem(p_41421_)));
 
-            colors.add(ChatFormatting.GREEN);
-            listed.add(MODID + ".augments_storage_xprate");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+storageAugment.getAdditionalXpStoragePerItem(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.GREEN);
+        listed.add(MODID + ".augments_storage_xprate");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredStorage.getAdditionalXpStoragePerItem(p_41421_)));;
 
-            colors.add(ChatFormatting.LIGHT_PURPLE);
-            listed.add(MODID + ".augments_storage_dustrate");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+storageAugment.getAdditionalDustStoragePerItem(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.LIGHT_PURPLE);
+        listed.add(MODID + ".augments_storage_dustrate");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredStorage.getAdditionalDustStoragePerItem(p_41421_)));
 
-            colors.add(ChatFormatting.GOLD);
-            listed.add(MODID + ".augments_insertable");
-            colors.add(ChatFormatting.WHITE);
-            listed.add(""+storageAugment.getAllowedInsertAmount(p_41421_.getItem())+"");
+        colors.add(ChatFormatting.GOLD);
+        listed.add(MODID + ".augments_insertable");
+        colors.add(ChatFormatting.WHITE);
+        listed.add(String.valueOf(AugmentTieredStorage.getAllowedInsertAmount(p_41421_)));
 
-
-            MowLibTooltipUtils.addTooltipShiftMessageMultiWithStyle(MODID,p_41423_,listed,colors);
-        }
+        MowLibTooltipUtils.addTooltipShiftMessageMultiWithStyle(MODID,p_41423_,listed,colors);
     }
 
 

--- a/src/main/java/com/mowmaster/pedestals/Items/Tools/PedestalManifestTool.java
+++ b/src/main/java/com/mowmaster/pedestals/Items/Tools/PedestalManifestTool.java
@@ -7,7 +7,6 @@ import com.mowmaster.mowlib.Networking.MowLibPacketParticles;
 import com.mowmaster.pedestals.Blocks.Pedestal.BasePedestalBlock;
 import com.mowmaster.pedestals.Blocks.Pedestal.BasePedestalBlockEntity;
 import com.mowmaster.pedestals.PedestalUtils.References;
-import com.mowmaster.pedestals.Registry.DeferredRegisterItems;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.core.BlockPos;
@@ -164,15 +163,11 @@ public class PedestalManifestTool extends BaseTool implements IPedestalTool
                         boolean hasCollide = ped.hasNoCollide();
                         MowLibCompoundTagUtils.writeBooleanToNBT(MODID,getTagOnItem,hasRoundRobin,"_hasrobin");
                         MowLibCompoundTagUtils.writeBooleanToNBT(MODID,getTagOnItem,hasCollide,"_hascollide");
-                        int getNumAugmentsSpeed = (hasSpeed)?(ped.getSpeed()):(0);
-                        int getNumAugmentsCapacity = (hasCapacity)?(ped.getCapacity()):(0);
-                        int getNumAugmentsStorage = (hasStorage)?(ped.getStorage()):(0);
-                        int getNumAugmentsRange = (hasRange)?(ped.getRange()):(0);
 
-                        MowLibCompoundTagUtils.writeIntegerToNBT(MODID,getTagOnItem,getNumAugmentsSpeed,"_intaugmentspeed");
-                        MowLibCompoundTagUtils.writeIntegerToNBT(MODID,getTagOnItem,getNumAugmentsCapacity,"_intaugmentcapacity");
-                        MowLibCompoundTagUtils.writeIntegerToNBT(MODID,getTagOnItem,getNumAugmentsStorage,"_intaugmentstorage");
-                        MowLibCompoundTagUtils.writeIntegerToNBT(MODID,getTagOnItem,getNumAugmentsRange,"_intaugmentrange");
+                        MowLibCompoundTagUtils.writeIntegerToNBT(MODID,getTagOnItem,ped.numAugmentsSpeed(),"_intaugmentspeed");
+                        MowLibCompoundTagUtils.writeIntegerToNBT(MODID,getTagOnItem,ped.numAugmentsCapacity(),"_intaugmentcapacity");
+                        MowLibCompoundTagUtils.writeIntegerToNBT(MODID,getTagOnItem,ped.numAugmentsStorage(),"_intaugmentstorage");
+                        MowLibCompoundTagUtils.writeIntegerToNBT(MODID,getTagOnItem,ped.numAugmentsRange(),"_intaugmentrange");
 
                         MowLibMessageUtils.messagePopup(player,ChatFormatting.WHITE,MODID + ".manifest.create");
                         MowLibPacketHandler.sendToNearby(p_41432_,player.getOnPos(),new MowLibPacketParticles(MowLibPacketParticles.EffectType.ANY_COLOR_CENTERED,pos.getX(),pos.getY()+1.0D,pos.getZ(),0,0,200));

--- a/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlock.java
+++ b/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlock.java
@@ -575,7 +575,7 @@ public class BasePedestalBlock extends MowLibBaseBlock implements SimpleWaterlog
                 }
                 else if(itemInOffHand.getItem() instanceof IPedestalUpgrade)
                 {
-                    if(pedestal.attemptAddCoin(itemInOffHand)) {
+                    if(pedestal.attemptAddCoin(itemInOffHand, p_60506_)) {
                         return InteractionResult.SUCCESS;
                     }
                 }

--- a/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlock.java
+++ b/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlock.java
@@ -392,27 +392,27 @@ public class BasePedestalBlock extends MowLibBaseBlock implements SimpleWaterlog
                 ItemStack itemInHand = p_60502_.getMainHandItem();
                 ItemStack itemInOffHand = p_60502_.getOffhandItem();
 
-                if(pedestal.hasCoin() && itemInOffHand.getItem().equals(DeferredRegisterItems.TOOL_UPGRADETOOL.get()))
+                if(pedestal.hasCoin() && itemInOffHand.is(DeferredRegisterItems.TOOL_UPGRADETOOL.get()))
                 {
                     //Method for upgrades to do things before removal
                     pedestal.actionOnRemovedFromPedestal(1);
                     ItemHandlerHelper.giveItemToPlayer(p_60502_,pedestal.removeCoin());
                 }
-                else if(pedestal.hasTool() && itemInOffHand.getItem().equals(DeferredRegisterItems.TOOL_TOOLSWAPPER.get()))
+                else if(pedestal.hasTool() && itemInOffHand.is(DeferredRegisterItems.TOOL_TOOLSWAPPER.get()))
                 {
                     pedestal.actionOnNeighborBelowChange(getPosOfBlockBelow(p_60499_, p_60501_, 1));
                     pedestal.updatePedestalPlayer(pedestal);
                     ItemHandlerHelper.giveItemToPlayer(p_60502_,pedestal.removeAllTool());
                 }
-                else if(pedestal.hasFilter() && itemInOffHand.getItem().equals(DeferredRegisterItems.TOOL_FILTERTOOL.get()))
+                else if(pedestal.hasFilter() && itemInOffHand.is(DeferredRegisterItems.TOOL_FILTERTOOL.get()))
                 {
-                    ItemHandlerHelper.giveItemToPlayer(p_60502_,pedestal.removeFilter(true));
+                    ItemHandlerHelper.giveItemToPlayer(p_60502_,pedestal.removeFilter());
                 }
-                else if(pedestal.hasLight() && itemInOffHand.getItem().equals(Items.GLOWSTONE))
+                else if(pedestal.hasLight() && itemInOffHand.is(Items.GLOWSTONE))
                 {
                     ItemHandlerHelper.giveItemToPlayer(p_60502_,pedestal.removeLight());
                 }
-                else if(pedestal.hasRedstone() && itemInOffHand.getItem().equals(Items.REDSTONE))
+                else if(pedestal.hasRedstone() && itemInOffHand.is(Items.REDSTONE))
                 {
                     if(p_60502_.isShiftKeyDown())
                     {
@@ -423,15 +423,15 @@ public class BasePedestalBlock extends MowLibBaseBlock implements SimpleWaterlog
                         ItemHandlerHelper.giveItemToPlayer(p_60502_,pedestal.removeRedstone());
                     }
                 }
-                else if(pedestal.hasRRobin() && itemInOffHand.getItem().equals(DeferredRegisterItems.AUGMENT_PEDESTAL_ROUNDROBIN.get()))
+                else if(pedestal.hasRRobin() && itemInOffHand.is(DeferredRegisterItems.AUGMENT_PEDESTAL_ROUNDROBIN.get()))
                 {
                     ItemHandlerHelper.giveItemToPlayer(p_60502_,pedestal.removeRRobin());
                 }
-                else if(pedestal.hasRenderAugment() && itemInOffHand.getItem().equals(DeferredRegisterItems.AUGMENT_PEDESTAL_RENDERDIFFUSER.get()))
+                else if(pedestal.hasRenderAugment() && itemInOffHand.is(DeferredRegisterItems.AUGMENT_PEDESTAL_RENDERDIFFUSER.get()))
                 {
                     ItemHandlerHelper.giveItemToPlayer(p_60502_,pedestal.removeRenderAugment());
                 }
-                else if(pedestal.hasNoCollide() && itemInOffHand.getItem().equals(DeferredRegisterItems.AUGMENT_PEDESTAL_NOCOLLIDE.get()))
+                else if(pedestal.hasNoCollide() && itemInOffHand.is(DeferredRegisterItems.AUGMENT_PEDESTAL_NOCOLLIDE.get()))
                 {
                     ItemHandlerHelper.giveItemToPlayer(p_60502_,pedestal.removeNoCollide());
                 }
@@ -573,144 +573,94 @@ public class BasePedestalBlock extends MowLibBaseBlock implements SimpleWaterlog
                         return InteractionResult.FAIL;
                     }
                 }
-                else if(itemInOffHand.getItem() instanceof IPedestalUpgrade upgrade)
+                else if(itemInOffHand.getItem() instanceof IPedestalUpgrade)
                 {
-                    if(!pedestal.hasCoin() && pedestal.addCoin(p_60506_,itemInOffHand,true))
-                    {
-                        pedestal.addCoin(p_60506_,itemInOffHand,false);
-                        upgrade.actionOnAddedToPedestal(p_60506_, pedestal,pedestal.getCoinOnPedestal());
-                        p_60506_.getOffhandItem().shrink(1);
+                    if(pedestal.attemptAddCoin(itemInOffHand)) {
                         return InteractionResult.SUCCESS;
                     }
                 }
                 else if(itemInOffHand.getItem() instanceof IPedestalFilter)
                 {
-                    if(!pedestal.hasFilter() && pedestal.addFilter(itemInOffHand,true))
-                    {
-                        pedestal.addFilter(itemInOffHand,false);
-                        p_60506_.getOffhandItem().shrink(1);
+                    if(pedestal.attemptAddFilter(itemInOffHand)) {
                         return InteractionResult.SUCCESS;
                     }
                 }
                 else if(itemInOffHand.getItem() instanceof IPedestalWorkCard)
                 {
-                    if(!pedestal.hasWorkCard() && pedestal.addWorkCard(itemInOffHand,true))
+                    if(pedestal.attemptAddWorkCard(itemInOffHand))
                     {
-                        pedestal.addWorkCard(itemInOffHand,false);
-                        p_60506_.getOffhandItem().shrink(1);
                         return InteractionResult.SUCCESS;
                     }
                 }
                 else if(itemInOffHand.getItem().equals(Items.GLOWSTONE))
                 {
-                    if(!pedestal.hasLight())
+                    if(pedestal.attemptAddLight(itemInOffHand))
                     {
-                        if(pedestal.addLight())
-                        {
-                            p_60506_.getOffhandItem().shrink(1);
-                            return InteractionResult.SUCCESS;
-                        }
+                        return InteractionResult.SUCCESS;
                     }
                 }
                 else if(itemInOffHand.getItem().equals(Items.REDSTONE))
                 {
-                    if(pedestal.getRedstonePowerNeeded()<15)
+                    if(pedestal.attemptAddRedstone(itemInOffHand))
                     {
-                        if(pedestal.addRedstone())
-                        {
-                            p_60506_.getOffhandItem().shrink(1);
-                            return InteractionResult.SUCCESS;
-                        }
+                        return InteractionResult.SUCCESS;
                     }
                 }
                 else if(itemInOffHand.getItem().equals(DeferredRegisterItems.AUGMENT_PEDESTAL_ROUNDROBIN.get()))
                 {
-                    if(!pedestal.hasRRobin())
-                    {
-                        if(pedestal.addRRobin(p_60506_.getOffhandItem()))
-                        {
-                            p_60506_.getOffhandItem().shrink(1);
-                            return InteractionResult.SUCCESS;
-                        }
+                    if(pedestal.attemptAddRRobin(itemInOffHand)) {
+                        return InteractionResult.SUCCESS;
                     }
                 }
                 else if(itemInOffHand.getItem().equals(DeferredRegisterItems.AUGMENT_PEDESTAL_RENDERDIFFUSER.get()))
                 {
-                    if(!pedestal.hasRenderAugment())
+                    if(pedestal.attemptAddRenderAugment(itemInOffHand))
                     {
-                        if(pedestal.addRenderAugment(p_60506_.getOffhandItem()))
-                        {
-                            p_60506_.getOffhandItem().shrink(1);
-                            return InteractionResult.SUCCESS;
-                        }
+                        return InteractionResult.SUCCESS;
                     }
                 }
                 else if(itemInOffHand.getItem().equals(DeferredRegisterItems.AUGMENT_PEDESTAL_NOCOLLIDE.get()))
                 {
-                    if(!pedestal.hasNoCollide())
+                    if(pedestal.attemptAddNoCollide(itemInOffHand))
                     {
-                        if(pedestal.addNoCollide(p_60506_.getOffhandItem()))
-                        {
-                            p_60506_.getOffhandItem().shrink(1);
-                            return InteractionResult.SUCCESS;
-                        }
+                        return InteractionResult.SUCCESS;
                     }
                 }
                 else if(itemInOffHand.getItem() instanceof AugmentTieredSpeed)
                 {
-                    if(pedestal.canInsertAugmentSpeed(itemInOffHand))
+                    if(pedestal.attemptAddSpeed(itemInOffHand))
                     {
-                        if(pedestal.addSpeed(p_60506_.getOffhandItem()))
-                        {
-                            p_60506_.getOffhandItem().shrink(1);
-                            return InteractionResult.SUCCESS;
-                        }
+                        return InteractionResult.SUCCESS;
                     }
                 }
                 else if(itemInOffHand.getItem() instanceof AugmentTieredCapacity)
                 {
-                    if(pedestal.canInsertAugmentCapacity(itemInOffHand))
+                    if(pedestal.attemptAddCapacity(itemInOffHand))
                     {
-                        if(pedestal.addCapacity(p_60506_.getOffhandItem()))
-                        {
-                            p_60506_.getOffhandItem().shrink(1);
-                            return InteractionResult.SUCCESS;
-                        }
+                        return InteractionResult.SUCCESS;
                     }
                 }
                 else if(itemInOffHand.getItem() instanceof AugmentTieredStorage)
                 {
-                    if(pedestal.canInsertAugmentStorage(itemInOffHand))
+                    if(pedestal.attemptAddStorage(itemInOffHand))
                     {
-                        if(pedestal.addStorage(p_60506_.getOffhandItem()))
-                        {
-                            p_60506_.getOffhandItem().shrink(1);
-                            return InteractionResult.SUCCESS;
-                        }
+                        return InteractionResult.SUCCESS;
                     }
                 }
                 else if(itemInOffHand.getItem() instanceof AugmentTieredRange)
                 {
-                    if(pedestal.canInsertAugmentRange(itemInOffHand))
+                    if(pedestal.attemptAddRange(itemInOffHand))
                     {
-                        if(pedestal.addRange(p_60506_.getOffhandItem()))
-                        {
-                            p_60506_.getOffhandItem().shrink(1);
-                            return InteractionResult.SUCCESS;
-                        }
+                        return InteractionResult.SUCCESS;
                     }
                 }
                 else if(pedestal.isAllowedTool(itemInOffHand))
                 {
-                    if(pedestal.canInsertTool(itemInOffHand))
+                    if(pedestal.attemptAddTool(itemInOffHand))
                     {
-                        if(pedestal.addTool(p_60506_.getOffhandItem()))
-                        {
-                            pedestal.actionOnNeighborBelowChange(getPosOfBlockBelow(p_60503_, p_60505_, 1));
-                            pedestal.updatePedestalPlayer(pedestal);
-                            p_60506_.getOffhandItem().shrink(1);
-                            return InteractionResult.SUCCESS;
-                        }
+                        pedestal.actionOnNeighborBelowChange(getPosOfBlockBelow(p_60503_, p_60505_, 1));
+                        pedestal.updatePedestalPlayer(pedestal);
+                        return InteractionResult.SUCCESS;
                     }
                 }
                 else if(DYES.contains(itemInOffHand.getItem()))

--- a/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlockEntity.java
+++ b/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlockEntity.java
@@ -1790,10 +1790,12 @@ The remaining ItemStack that was not inserted (if the entire stack is accepted, 
         return privateItems.extractItem(PrivateInventorySlot.COIN, 1, false);
     }
 
-    public boolean attemptAddCoin(ItemStack stack)
+    public boolean attemptAddCoin(ItemStack stack, Player player)
     {
         if (privateItems.isItemValid(PrivateInventorySlot.COIN, stack)) {
             privateItems.insertItem(PrivateInventorySlot.COIN, stack.split(1), false);
+            IPedestalUpgrade upgrade = (IPedestalUpgrade)stack.getItem();
+            upgrade.actionOnAddedToPedestal(player, this, stack);
             // update();
             return true;
         } else {


### PR DESCRIPTION
* Removed the unnecessary `LazyOptional` wrapping of the private inventory as this capability presumably is never meant to be exposed (either way it is not needed when within `BasePedestalBlockEntity` itself, which is also true for the other handlers which have remained untouched in this PR).
* Updated `AugmentsTiered*` to use `static` methods and `ItemStack`s to reduce unneeded `.getItem()` and `instanceof` calls.
* Moved the responsibility for manipulating the `ItemStack` on insertion to the private inventory from `BasePedestalBlock` to `BasePedestalBlockEntity`. Additionally removed the `simulate` arguments for the few item types that had them as they were always called with `simulate=true` immediately followed by `simulate=false` (i.e. there seems to be no current use for simulation).
* Added constants for defining the `PrivateInventorySlot`s to `BasePedestalBlockEntity` for consistency across all items handled by that inventory.
* Removed most of the duplicative tests when interacting with the private inventory (left the duplication checking the type of item within the `ItemStack` for the `attemptAdd*` calls even though the only caller of those methods already ensures the type of item is correct).