### PR TITLE
Fix for issue #183: bug in offhand linking. Includes refactor.

### DIFF
--- a/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlock.java
+++ b/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlock.java
@@ -249,107 +249,37 @@ public class BasePedestalBlock extends MowLibBaseBlock implements SimpleWaterlog
     public void setPlacedBy(Level p_49847_, BlockPos p_49848_, BlockState p_49849_, @org.jetbrains.annotations.Nullable LivingEntity p_49850_, ItemStack p_49851_) {
         if(!p_49847_.isClientSide())
         {
-            if(p_49850_ instanceof Player)
+            if(p_49850_ instanceof Player player)
             {
-                Player player = ((Player)p_49850_);
-                String linksucess = MODID + ".tool_link_success";
-                String linkunsuccess = MODID + ".tool_link_unsucess";
-                String linkremoved = MODID + ".tool_link_removed";
-                String linkitsself = MODID + ".tool_link_itsself";
-                String linknetwork = MODID + ".tool_link_network";
-                String linkdistance = MODID + ".tool_link_distance";
-                if(player.getOffhandItem().getItem().equals(DeferredRegisterItems.TOOL_LINKINGTOOL.get()))
+                ItemStack offhandItemStack = player.getOffhandItem();
+                if(offhandItemStack.hasTag() && offhandItemStack.isEnchanted())
                 {
-                    LinkingTool tool = ((LinkingTool)player.getOffhandItem().getItem());
-                    if(player.getOffhandItem().hasTag() && player.getOffhandItem().isEnchanted())
+
+                    if(offhandItemStack.is(DeferredRegisterItems.TOOL_LINKINGTOOL.get()))
                     {
                         //Checks if clicked blocks is a Pedestal
                         if(p_49847_.getBlockState(p_49848_).getBlock() instanceof BasePedestalBlock)
                         {
-                            //Checks Tile at location to make sure its a TilePedestal
-                            BlockEntity tileEntity = p_49847_.getBlockEntity(p_49848_);
-                            if (tileEntity instanceof BasePedestalBlockEntity) {
-                                BasePedestalBlockEntity tilePedestal = (BasePedestalBlockEntity) tileEntity;
-
-                                BlockEntity tileEntitySender = p_49847_.getBlockEntity(p_49848_);
-                                if (tileEntity instanceof BasePedestalBlockEntity) {
-                                    BasePedestalBlockEntity tileSender = (BasePedestalBlockEntity) tileEntitySender;
-
-                                    //checks if connecting pedestal is out of range of the senderPedestal
-                                    if(tilePedestal.isPedestalInRange(tileSender,tool.getStoredPosition(player.getOffhandItem())))
-                                    {
-                                        //Checks if pedestals to be linked are on same networks or if one is neutral
-                                        if(tilePedestal.canLinkToPedestalNetwork(tool.getStoredPosition(player.getOffhandItem())))
-                                        {
-                                            //If stored location isnt the same as the connecting pedestal
-                                            if(!tilePedestal.isSamePedestal(tool.getStoredPosition(player.getOffhandItem())))
-                                            {
-                                                //Checks if the conenction hasnt been made once already yet
-                                                if(!tilePedestal.isAlreadyLinked(tool.getStoredPosition(player.getOffhandItem())))
-                                                {
-                                                    //Checks if senderPedestal has locationSlots available
-                                                    //System.out.println("Stored Locations: "+ tilePedestal.getNumberOfStoredLocations());
-                                                    if(tilePedestal.storeNewLocation(tool.getStoredPosition(player.getOffhandItem())))
-                                                    {
-                                                        MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE,linksucess);
-                                                    }
-                                                    else MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE,linkunsuccess);
-                                                }
-                                            }
-                                            else MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE,linkitsself);
-                                        }
-                                        else MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE,linknetwork);
-                                    }
-                                    else MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE,linkdistance);
-                                }
+                            // Checks Tile at location to make sure its a TilePedestal
+                            if (p_49847_.getBlockEntity(p_49848_) instanceof BasePedestalBlockEntity sendingPedestal) {
+                                LinkingTool tool = (LinkingTool)offhandItemStack.getItem();
+                                BlockPos receivingPos = tool.getStoredPosition(offhandItemStack);
+                                sendingPedestal.attemptUpdateLink(receivingPos, player, MODID + ".tool_link_success_linkingtool");
                             }
                         }
                     }
-                }
-                else if(player.getOffhandItem().getItem().equals(DeferredRegisterItems.TOOL_LINKINGTOOLBACKWARDS.get()))
-                {
-                    LinkingToolBackwards tool = ((LinkingToolBackwards)player.getOffhandItem().getItem());
-                    if(player.getOffhandItem().hasTag() && player.getOffhandItem().isEnchanted())
+                    else if(offhandItemStack.is(DeferredRegisterItems.TOOL_LINKINGTOOLBACKWARDS.get()))
                     {
                         //Checks if clicked blocks is a Pedestal
                         if(p_49847_.getBlockState(p_49848_).getBlock() instanceof BasePedestalBlock)
                         {
+                            LinkingToolBackwards tool = (LinkingToolBackwards)offhandItemStack.getItem();
+                            BlockPos sendingPos = tool.getStoredPosition(offhandItemStack);
+
                             //Checks Tile at location to make sure its a TilePedestal
-                            BlockEntity tileEntity = p_49847_.getBlockEntity(tool.getStoredPosition(player.getOffhandItem()));
-                            if (tileEntity instanceof BasePedestalBlockEntity) {
-                                BasePedestalBlockEntity tilePedestal = (BasePedestalBlockEntity) tileEntity;
-
-                                BlockEntity tileEntitySender = p_49847_.getBlockEntity(tool.getStoredPosition(player.getOffhandItem()));
-                                if (tileEntity instanceof BasePedestalBlockEntity) {
-                                    BasePedestalBlockEntity tileSender = (BasePedestalBlockEntity) tileEntitySender;
-
-                                    //checks if connecting pedestal is out of range of the senderPedestal
-                                    if(tileSender.isPedestalInRange(tilePedestal,p_49848_))
-                                    {
-                                        //Checks if pedestals to be linked are on same networks or if one is neutral
-                                        if(tileSender.canLinkToPedestalNetwork(p_49848_))
-                                        {
-                                            //If stored location isnt the same as the connecting pedestal
-                                            if(!tileSender.isSamePedestal(p_49848_))
-                                            {
-                                                //Checks if the conenction hasnt been made once already yet
-                                                if(!tileSender.isAlreadyLinked(p_49848_))
-                                                {
-                                                    //Checks if senderPedestal has locationSlots available
-                                                    //System.out.println("Stored Locations: "+ tilePedestal.getNumberOfStoredLocations());
-                                                    if(tileSender.storeNewLocation(p_49848_))
-                                                    {
-                                                        MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE,linksucess);
-                                                    }
-                                                    else MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE,linkunsuccess);
-                                                }
-                                            }
-                                            else MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE,linkitsself);
-                                        }
-                                        else MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE,linknetwork);
-                                    }
-                                    else MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE,linkdistance);
-                                }
+                            if (p_49847_.getBlockEntity(sendingPos) instanceof BasePedestalBlockEntity sendingPedestal) {
+                                BlockPos receivingPos = p_49848_;
+                                sendingPedestal.attemptUpdateLink(receivingPos, player, MODID + ".tool_link_success_backwardslinkingtool");
                             }
                         }
                     }

--- a/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlockEntity.java
+++ b/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlockEntity.java
@@ -25,6 +25,7 @@ import com.mowmaster.pedestals.Registry.DeferredBlockEntityTypes;
 import com.mowmaster.pedestals.Registry.DeferredRegisterItems;
 
 import static com.mowmaster.pedestals.Blocks.Pedestal.BasePedestalBlock.*;
+import static com.mowmaster.pedestals.PedestalUtils.References.MODID;
 
 import com.mowmaster.pedestals.Registry.DeferredRegisterTileBlocks;
 import net.minecraft.ChatFormatting;
@@ -1020,25 +1021,36 @@ public class BasePedestalBlockEntity extends MowLibBaseBlockEntity
         return  range + getRangeIncrease();
     }
 
-    public boolean isPedestalInRange(BasePedestalBlockEntity pedestalCurrent, BlockPos pedestalToBeLinked)
+    public boolean isPedestalInRange(BlockPos targetPos)
     {
-        int range = pedestalCurrent.getLinkingRange();
-        int x = pedestalToBeLinked.getX();
-        int y = pedestalToBeLinked.getY();
-        int z = pedestalToBeLinked.getZ();
-        int x1 = pedestalCurrent.getPos().getX();
-        int y1 = pedestalCurrent.getPos().getY();
-        int z1 = pedestalCurrent.getPos().getZ();
-        int xF = Math.abs(Math.subtractExact(x,x1));
-        int yF = Math.abs(Math.subtractExact(y,y1));
-        int zF = Math.abs(Math.subtractExact(z,z1));
-
-        if(xF>range || yF>range || zF>range)
-        {
-            return false;
-        }
-        else return true;
+        BlockPos distanceVector = getPos().subtract(targetPos);
+        int range = getLinkingRange();
+        return Math.abs(distanceVector.getX()) < range &&
+            Math.abs(distanceVector.getY()) < range &&
+            Math.abs(distanceVector.getZ()) < range;
     }
+
+    public boolean attemptUpdateLink(BlockPos targetPos, Player player, String successLocalizedMessage) {
+        boolean attemptSuccessful = false;
+        if (!isPedestalInRange(targetPos)) {
+            MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE, MODID + ".tool_link_distance");
+        } else if (!canLinkToPedestalNetwork(targetPos)) {
+            MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE, MODID + ".tool_link_network");
+        } else if (!isSamePedestal(targetPos)) {
+            MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE, MODID + ".tool_link_itsself");
+        } else if (isAlreadyLinked(targetPos)) {
+            // this path can only occur via the linking tools, which helps because we don't need a parameter to control it
+            attemptSuccessful = true;
+            removeLocation(targetPos);
+            MowLibMessageUtils.messagePopup(player, ChatFormatting.WHITE, MODID + ".tool_link_removed");
+        } else if (storeNewLocation(targetPos)) {
+            attemptSuccessful = true;
+            MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE, successLocalizedMessage);
+        } else {
+            MowLibMessageUtils.messagePlayerChat(player, ChatFormatting.WHITE, MODID + ".tool_link_unsucess");
+        }
+        return attemptSuccessful;
+     }
 
     /*============================================================================
     ==============================================================================
@@ -3173,23 +3185,16 @@ The remaining ItemStack that was not inserted (if the entire stack is accepted, 
         return false;
     }
 
-    public boolean isSamePedestal(BlockPos pedestalToBeLinked)
+    public boolean isSamePedestal(BlockPos targetPos)
     {
-        BlockPos thisPedestal = this.getPos();
-
-        if(thisPedestal.equals(pedestalToBeLinked))
-        {
-            return true;
-        }
-
-        return false;
+        return !getPos().equals(targetPos);
     }
 
     //Checks when linking pedestals if the two being linked are the same block and within range
-    public boolean canLinkToPedestalNetwork(BlockPos pedestalToBeLinked)
+    public boolean canLinkToPedestalNetwork(BlockPos targetPos)
     {
         //Check to see if pedestal to be linked is a block pedestal
-        if(level.getBlockState(pedestalToBeLinked).getBlock() instanceof BasePedestalBlock)
+        if(level.getBlockState(targetPos).getBlock() instanceof BasePedestalBlock)
         {
             //isPedestalInRange(tileCurrent,pedestalToBeLinked);
             return true;


### PR DESCRIPTION
* Consolidates tests/messaging around establishing and removing links to a pedestal to `BasePedestalBlockEntity`.
* Fixes an off-by-1 error in `isPedestalInRange` (at least on mainline you seem to be able to link to the pedestal that's 1 block outside the rendered red bounding box).
* Inverts the conditions in testing for a valid connection to reduce nesting and bring the error messages directly below their cause.
* I've left the check to `canLinkToPedestalNetwork` which I'm not sure is required given it doesn't do anything today (if you're fine following a precondition that you only ever call `attemptUpdateLink` between two pedestals, which is the case today, this check can just be removed).