### PR TITLE
Fix for RRobin Augment transfer behavior.

### DIFF
--- a/src/main/java/com/mowmaster/pedestals/Items/Tools/LinkingTool.java
+++ b/src/main/java/com/mowmaster/pedestals/Items/Tools/LinkingTool.java
@@ -100,7 +100,7 @@ public class LinkingTool extends BaseTool implements IPedestalTool
                             if(tile instanceof BasePedestalBlockEntity)
                             {
                                 BasePedestalBlockEntity ped = ((BasePedestalBlockEntity)tile);
-                                this.storedPositionList = ped.getLocationList();
+                                this.storedPositionList = ped.getLinkedLocations();
                             }
                             //Gets Pedestal Clicked on Pos
                             this.storedPosition = pos;
@@ -124,7 +124,7 @@ public class LinkingTool extends BaseTool implements IPedestalTool
                                 //Checks Tile at location to make sure its a TilePedestal
                                 if (world.getBlockEntity(pos) instanceof BasePedestalBlockEntity senderPedestal) {
                                     BlockPos receivingPos = getStoredPosition(stackInHand);
-                                    int previousStoredCount = senderPedestal.getNumberOfStoredLocations();
+                                    int previousLinkedCount = senderPedestal.getNumLinkedPedestals();
                                     if (senderPedestal.attemptUpdateLink(receivingPos, player, linksuccess)) {
                                         // successfully updated link, clean-up the tool
                                         Map<Enchantment, Integer> enchantsNone = Maps.<Enchantment, Integer>newLinkedHashMap();
@@ -132,7 +132,7 @@ public class LinkingTool extends BaseTool implements IPedestalTool
 
                                         // TODO: this maintains existing behavior of not clearing the `storedPosition` if
                                         // a connection was removed, which might have just been a bug?
-                                        if (senderPedestal.getNumberOfStoredLocations() > previousStoredCount) {
+                                        if (senderPedestal.getNumLinkedPedestals() > previousLinkedCount) {
                                             storedPosition = defaultPos;
                                             storedPositionList = new ArrayList<>();
                                             writePosToNBT(stackInHand);

--- a/src/main/java/com/mowmaster/pedestals/Items/Tools/LinkingToolBackwards.java
+++ b/src/main/java/com/mowmaster/pedestals/Items/Tools/LinkingToolBackwards.java
@@ -96,7 +96,7 @@ public class LinkingToolBackwards extends BaseTool implements IPedestalTool
                             if(tile instanceof BasePedestalBlockEntity)
                             {
                                 BasePedestalBlockEntity ped = ((BasePedestalBlockEntity)tile);
-                                this.storedPositionList = ped.getLocationList();
+                                this.storedPositionList = ped.getLinkedLocations();
                             }
                             //Gets Pedestal Clicked on Pos
                             this.storedPosition = pos;
@@ -122,7 +122,7 @@ public class LinkingToolBackwards extends BaseTool implements IPedestalTool
                             {
                                 //Checks Tile at location to make sure its a TilePedestal
                                 if (world.getBlockEntity(senderPos) instanceof BasePedestalBlockEntity senderPedestal) {
-                                    int previousStoredCount = senderPedestal.getNumberOfStoredLocations();
+                                    int previousLinkedCount = senderPedestal.getNumLinkedPedestals();
                                     if (senderPedestal.attemptUpdateLink(pos, player, linksucess)) {
                                         // successfully updated link, clean-up the tool
                                         Map<Enchantment, Integer> enchantsNone = Maps.<Enchantment, Integer>newLinkedHashMap();
@@ -130,7 +130,7 @@ public class LinkingToolBackwards extends BaseTool implements IPedestalTool
 
                                         // TODO: this maintains existing behavior of not clearing the `storedPosition` if
                                         // a connection was removed, which might have just been a bug?
-                                        if (senderPedestal.getNumberOfStoredLocations() > previousStoredCount) {
+                                        if (senderPedestal.getNumLinkedPedestals() > previousLinkedCount) {
                                             storedPosition = defaultPos;
                                             storedPositionList = new ArrayList<>();
                                             writePosToNBT(stackInHand);

--- a/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlockEntity.java
+++ b/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlockEntity.java
@@ -1787,9 +1787,12 @@ The remaining ItemStack that was not inserted (if the entire stack is accepted, 
     public boolean attemptAddCoin(ItemStack stack, Player player)
     {
         if (privateItems.isItemValid(PrivateInventorySlot.COIN, stack)) {
-            privateItems.insertItem(PrivateInventorySlot.COIN, stack.split(1), false);
-            IPedestalUpgrade upgrade = (IPedestalUpgrade)stack.getItem();
-            upgrade.actionOnAddedToPedestal(player, this, stack);
+            // stack.split might reduce `stack` to an empty stack, so if we need to use any property of the item being
+            // insert we need to make a reference to it it prior to insertion.
+            ItemStack toInsert = stack.split(1);
+            privateItems.insertItem(PrivateInventorySlot.COIN, toInsert, false);
+            IPedestalUpgrade upgrade = (IPedestalUpgrade)toInsert.getItem();
+            upgrade.actionOnAddedToPedestal(player, this, toInsert);
             // update();
             return true;
         } else {
@@ -2434,9 +2437,12 @@ The remaining ItemStack that was not inserted (if the entire stack is accepted, 
     public boolean attemptAddFilter(ItemStack stack)
     {
         if (privateItems.isItemValid(PrivateInventorySlot.FILTER, stack)) {
-            privateItems.insertItem(PrivateInventorySlot.FILTER, stack.split(1), false);
+            // stack.split might reduce `stack` to an empty stack, so if we need to use any property of the item being
+            // insert we need to make a reference to it it prior to insertion.
+            ItemStack toInsert = stack.split(1);
+            privateItems.insertItem(PrivateInventorySlot.FILTER, toInsert, false);
             BlockState state = level.getBlockState(getPos());
-            BlockState newstate = MowLibColorReference.addColorToBlockState(DeferredRegisterTileBlocks.BLOCK_PEDESTAL.get().defaultBlockState(),MowLibColorReference.getColorFromStateInt(state)).setValue(WATERLOGGED, state.getValue(WATERLOGGED)).setValue(FACING, state.getValue(FACING)).setValue(LIT, state.getValue(LIT)).setValue(FILTER_STATUS, (((IPedestalFilter) stack.getItem()).getFilterType(stack))?(2):(1));
+            BlockState newstate = MowLibColorReference.addColorToBlockState(DeferredRegisterTileBlocks.BLOCK_PEDESTAL.get().defaultBlockState(),MowLibColorReference.getColorFromStateInt(state)).setValue(WATERLOGGED, state.getValue(WATERLOGGED)).setValue(FACING, state.getValue(FACING)).setValue(LIT, state.getValue(LIT)).setValue(FILTER_STATUS, (((IPedestalFilter) toInsert.getItem()).getFilterType(toInsert)?2:1));
             level.setBlock(getPos(),newstate,3);
             update();
             return true;

--- a/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlockEntityRenderer.java
+++ b/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlockEntityRenderer.java
@@ -51,7 +51,7 @@ public class BasePedestalBlockEntityRenderer implements BlockEntityRenderer<Base
             ItemStack toolStack = p_112307_.getToolStack();
             ItemStack coin = p_112307_.getCoinOnPedestal();
             ItemStack workCard = p_112307_.getWorkCardInPedestal();
-            List<BlockPos> linkedLocations = p_112307_.getLocationList();
+            List<BlockPos> linkedLocations = p_112307_.getLinkedLocations();
             BlockPos pos = p_112307_.getPos();
             Level world = p_112307_.getLevel();
             List<String> hudMessages = p_112307_.getHudLog();


### PR DESCRIPTION
* Reintroduced the behavior of removing connections if the target location is no longer a pedestal as part of `transferAction`. This required the use of `Iterator`s to traverse the collection, as that's the only safe way to remove elements during traversal). NOTE: if you use redstone to disable the sender pedestal, you can still remove + replace receiver pedestals without impacting their connection (as discussed this seems to be a desirable behavior).
* Updated `transferAction` to use the same code path regardless of whether the RRobin augment exists, through the use of Java's `List.subList` (which creates a "view" of the underlying collection that behaves as if it's the real collection but lets you slice the List to have the proper traversal order for RRobin) and indirection by having the actual logic within `transferActionImpl`.
* Removed some of the `*PedestalNetwork` checks as that seems to be an entirely unimplemented feature (and thus removing the code makes it easier to perform these changes -- they can be re-added later if needed). Additionally removed `canSendItemInPedestal` as it seems to be an unused function that was adjacent to what I was refactoring.
* Changed the check in `canSendToPedestal` to use `Level.isLoaded` (over the previous `LevelReader.isAreaLoaded` as this is marked as deprecated in the [Forge documentation](https://nekoyue.github.io/ForgeJavaDocs-NG/javadoc/1.19.3/net/minecraft/world/level/LevelReader.html#isAreaLoaded(net.minecraft.core.BlockPos,int)))
