### PR TITLE
Refactor of the `itemHandler/Capability`.

### DIFF
--- a/src/main/java/com/mowmaster/pedestals/Items/Upgrades/Pedestal/ItemUpgradeVoid.java
+++ b/src/main/java/com/mowmaster/pedestals/Items/Upgrades/Pedestal/ItemUpgradeVoid.java
@@ -74,19 +74,10 @@ public class ItemUpgradeVoid extends ItemUpgradeBase implements IHasModeTypes
     public void upgradeAction(Level level, BasePedestalBlockEntity pedestal, BlockPos pedestalPos, ItemStack coin)
     {
         //Items
-        if(canTransferItems(coin))
-        {
-            if(pedestal.hasItem())
-            {
-                for(int i=0;i<pedestal.getItemStacks().size();i++)
-                {
-                    if(passesFilter(pedestal,pedestal.getItemInPedestal(i),null,null,0,0, IItemMode.ItemTransferMode.ITEMS))
-                    {
-                        if(!pedestal.removeItemStack(i,true).isEmpty())
-                        {
-                            pedestal.removeItemStack(i,false);
-                        }
-                    }
+        if(canTransferItems(coin)) {
+            for (ItemStack itemStack: pedestal.getItemStacks()) {
+                if (passesFilter(pedestal, itemStack, null, null, 0, 0, IItemMode.ItemTransferMode.ITEMS)) {
+                    pedestal.removeItemStack(itemStack, false);
                 }
             }
         }


### PR DESCRIPTION
* This contains a substantial amount of clean-up of duplicative or dead code (e.g. `getItemInPedestalOrEmptySlot` was entirely removed, as it's was not only never called but is identical to `getItemInPedestal`).
* Refactors scanning the itemHandler slots for items into useful helpers like `maybeFirstNonEmptySlot` which returns a Java `Optional<Integer>` that is empty if there are no non-empty slots, and then leverages those helpers in all of the other functions to reduce duplication and make it easier to follow the code.
* Refactor of `ItemUpgradeVoid` to simply iterate over the `getItemStacks` result directly -- this removed the only use of the `removeItemStack(int slot, boolean simulate)` function (in favor of the `removeItemStack(ItemStack stackToRemove, boolean simulate)` function), and so I removed the now unused function.
* Also removes a debug `System.out.println` from the fluid handler code.


** I did perform testing of transfer, but given the scope of this change would highly recommend further testing or a deeper review as part of the PR **