### PR TITLE
Fix multi-inventory issues for BlockPlacer and Pump.

### DIFF
--- a/src/main/java/com/mowmaster/pedestals/Items/Upgrades/Pedestal/ItemUpgradeGenerator_FurnaceFuels.java
+++ b/src/main/java/com/mowmaster/pedestals/Items/Upgrades/Pedestal/ItemUpgradeGenerator_FurnaceFuels.java
@@ -1,8 +1,6 @@
 package com.mowmaster.pedestals.Items.Upgrades.Pedestal;
 
 import com.mowmaster.mowlib.MowLibUtils.MowLibCompoundTagUtils;
-import com.mowmaster.mowlib.MowLibUtils.MowLibContainerUtils;
-import com.mowmaster.mowlib.MowLibUtils.MowLibItemUtils;
 import com.mowmaster.mowlib.Networking.MowLibPacketHandler;
 import com.mowmaster.mowlib.Networking.MowLibPacketParticles;
 import com.mowmaster.pedestals.Blocks.Pedestal.BasePedestalBlockEntity;
@@ -10,29 +8,14 @@ import com.mowmaster.pedestals.Configs.PedestalConfig;
 import com.mowmaster.pedestals.PedestalUtils.References;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.Container;
-import net.minecraft.world.item.BucketItem;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
-import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
-import net.minecraft.world.item.crafting.SmeltingRecipe;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.entity.FurnaceBlockEntity;
 import net.minecraftforge.common.ForgeHooks;
-import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.items.IItemHandler;
-import net.minecraftforge.items.ItemHandlerHelper;
-
-import javax.annotation.Nullable;
-import java.util.*;
 
 import static com.mowmaster.pedestals.PedestalUtils.References.MODID;
 
-public class ItemUpgradeGenerator_FurnaceFuels extends ItemUpgradeBase
-{
+public class ItemUpgradeGenerator_FurnaceFuels extends ItemUpgradeBase {
     public ItemUpgradeGenerator_FurnaceFuels(Properties p_41383_) {
         super(new Properties());
     }
@@ -41,7 +24,6 @@ public class ItemUpgradeGenerator_FurnaceFuels extends ItemUpgradeBase
     public boolean canModifySpeed(ItemStack upgradeItemStack) {
         return true;
     }
-
 
     public int baseEnergyProduction(){ return PedestalConfig.COMMON.upgrade_generator_baseEnergyCost.get(); }
 
@@ -55,44 +37,25 @@ public class ItemUpgradeGenerator_FurnaceFuels extends ItemUpgradeBase
 
     }
 
-    private int calcFuelBurnTime(ItemStack inputFuel)
-    {
-        if(!inputFuel.isEmpty())
-        {
-            return ForgeHooks.getBurnTime(inputFuel,RecipeType.SMELTING);
-        }
-        return 0;
-    }
-
-
-
-    private int getBurnTimeLeft(BasePedestalBlockEntity pedestal)
-    {
+    private int getBurnTimeLeft(BasePedestalBlockEntity pedestal) {
         ItemStack coin = pedestal.getCoinOnPedestal();
         return MowLibCompoundTagUtils.readIntegerFromNBT(MODID, coin.getOrCreateTag(), "_numdelay");
     }
 
-    private void setBurnTime(BasePedestalBlockEntity pedestal, ItemStack input)
-    {
+    private void setBurnTime(BasePedestalBlockEntity pedestal, int burnTime) {
         ItemStack coin = pedestal.getCoinOnPedestal();
-        MowLibCompoundTagUtils.writeIntegerToNBT(MODID, coin.getOrCreateTag(), calcFuelBurnTime(input), "_numdelay");
+        MowLibCompoundTagUtils.writeIntegerToNBT(MODID, coin.getOrCreateTag(), burnTime, "_numdelay");
     }
 
-    private void resetBurnTime(BasePedestalBlockEntity pedestal)
-    {
-        ItemStack coin = pedestal.getCoinOnPedestal();
-        MowLibCompoundTagUtils.writeIntegerToNBT(MODID, coin.getOrCreateTag(), 0, "_numdelay");
-    }
-
-    private int incrementBurnTime(BasePedestalBlockEntity pedestal, boolean simulate)
-    {
+    private int incrementBurnTime(BasePedestalBlockEntity pedestal, boolean simulate) {
         ItemStack coin = pedestal.getCoinOnPedestal();
         int current = getBurnTimeLeft(pedestal);
-        if(current>0)
-        {
-            int ticks = 1+getSpeedTicksReduced(pedestal.getCoinOnPedestal());
-            int maxTicksReduced = (current>=ticks)?(ticks):(current);
-            if(!simulate)MowLibCompoundTagUtils.writeIntegerToNBT(MODID, coin.getOrCreateTag(), (current-maxTicksReduced), "_numdelay");
+        if (current > 0) {
+            int ticks = 1 + getSpeedTicksReduced(pedestal.getCoinOnPedestal());
+            int maxTicksReduced = Math.min(current, ticks);
+            if (!simulate) {
+                MowLibCompoundTagUtils.writeIntegerToNBT(MODID, coin.getOrCreateTag(), (current - maxTicksReduced), "_numdelay");
+            }
             return maxTicksReduced;
         }
         return 0;
@@ -115,34 +78,29 @@ public class ItemUpgradeGenerator_FurnaceFuels extends ItemUpgradeBase
     }*/
 
     @Override
-    public void updateAction(Level level, BasePedestalBlockEntity pedestal)
-    {
-        BlockPos pedestalPos = pedestal.getPos();
+    public void updateAction(Level level, BasePedestalBlockEntity pedestal) {
         ItemStack stackInPedestal = pedestal.getItemInPedestal();
+        int simulatedBurnTime = incrementBurnTime(pedestal, true);
 
-        if(getBurnTimeLeft(pedestal)>0)
-        {
-            int calcRF = incrementBurnTime(pedestal,true) * baseEnergyProduction();
-            if(pedestal.addEnergy(calcRF,true)>=calcRF)
-            {
-                incrementBurnTime(pedestal,false);
-                pedestal.addEnergy(calcRF,false);
-                if(pedestal.canSpawnParticles()) MowLibPacketHandler.sendToNearby(pedestal.getLevel(),pedestal.getPos(),new MowLibPacketParticles(MowLibPacketParticles.EffectType.ANY_COLOR_CENTERED,pedestalPos.getX(),pedestalPos.getY()+0.75D,pedestalPos.getZ(),255,0,0));
-            }
-        }
-        else if(!stackInPedestal.isEmpty())
-        {
-            ItemStack copyStack = stackInPedestal.copy();
-            copyStack.setCount(1);
-
-            if(calcFuelBurnTime(copyStack)>0)
-            {
-                if(!pedestal.removeItem(copyStack.getCount(),true).isEmpty())
-                {
-                    setBurnTime(pedestal,copyStack);
-                    pedestal.removeItem(copyStack.getCount(),false);
-                    if(copyStack.hasCraftingRemainingItem())pedestal.addItem(copyStack.getCraftingRemainingItem(),false);
+        if (simulatedBurnTime > 0) {
+            int calcRF = simulatedBurnTime * baseEnergyProduction();
+            if (pedestal.addEnergy(calcRF, true)>=calcRF) {
+                incrementBurnTime(pedestal, false);
+                pedestal.addEnergy(calcRF, false);
+                if (pedestal.canSpawnParticles()) {
+                    BlockPos pedestalPos = pedestal.getPos();
+                    MowLibPacketHandler.sendToNearby(pedestal.getLevel(),pedestalPos,new MowLibPacketParticles(MowLibPacketParticles.EffectType.ANY_COLOR_CENTERED,pedestalPos.getX(),pedestalPos.getY()+0.75D,pedestalPos.getZ(),255,0,0));
                 }
+            }
+        } else if(!stackInPedestal.isEmpty()) {
+            ItemStack toBurn = stackInPedestal.copy();
+            toBurn.setCount(1);
+            int burnTime = ForgeHooks.getBurnTime(toBurn, RecipeType.SMELTING);
+
+            if (burnTime > 0 && !pedestal.removeItemStack(toBurn,true).isEmpty()) {
+                setBurnTime(pedestal, burnTime);
+                pedestal.removeItemStack(toBurn, false);
+                if (toBurn.hasCraftingRemainingItem()) pedestal.addItem(toBurn.getCraftingRemainingItem(),false);
             }
         }
     }


### PR DESCRIPTION
* I don't have enough time to work through every upgrade listed in https://github.com/Mowmaster/Pedestals/issues/219, but this is basically the approach that each would need.
* I did my slightly more typical deeper clean (rearranging `if/else` branches to fold together duplicative cases, merging together many nested `if` statements to reduce indentation).

One thing I commented on in the code is that it seems `UseOnContext` does actually modify the passed in item stack, removing a single item from it, when the interaction result is a `InteractionResult.CONSUME`. Thus if `itemToPlace` didn't have the `.copy()` you could remove the check and explicit removal of the item as if it was placed it would be removed... but I left it as-is just incase there was something else I'm missing.