### PR TITLE
[1.20-Forge] Only Client Config + configurable rendering options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,13 @@ dependencies {
     // For more info:
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
+
+    implementation fg.deobf("curse.maven:pipez-443900:4629656")
+    //implementation fg.deobf("curse.maven:jade-324717:4654448")
+    // Configured not updated to 1.20.1 yet
+    implementation fg.deobf("curse.maven:catalogue-459701:4590890")
+    implementation fg.deobf("curse.maven:better-mods-button-541584:4613425")
+
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Pedestals
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=0.4.55
+mod_version=0.4.56
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/mowmaster/pedestals/Configs/PedestalConfig.java
+++ b/src/main/java/com/mowmaster/pedestals/Configs/PedestalConfig.java
@@ -1378,13 +1378,78 @@ public class PedestalConfig
         }
     }
 
+    public static class Client {
+
+        public final ForgeConfigSpec.BooleanValue pedestalRotateItems;
+        public final ForgeConfigSpec.BooleanValue pedestalRenderItems;
+        public final ForgeConfigSpec.BooleanValue pedestalRenderParticles;
+        public final ForgeConfigSpec.BooleanValue pedestalRenderHUD;
+        public final ForgeConfigSpec.BooleanValue pedestalRenderUpgrades;
+        public final ForgeConfigSpec.BooleanValue pedestalRenderToolSlot;
+        public final ForgeConfigSpec.BooleanValue pedestalRenderUpgradeInToolSlot;
+        public final ForgeConfigSpec.IntValue pedestalRenderDistance;
+        Client(ForgeConfigSpec.Builder builder) {
+            builder.comment("Pedestal rendering options").push("Pedestal");
+            pedestalRotateItems = builder
+                    .comment("Should items on pedestal rotate")
+                    .comment("§a§lLOW§f impact when §a§lTRUE")
+                    .comment("§2§lLOWEST§f impact when §c§lFALSE")
+                    .define("Rotate Items", true);
+            pedestalRenderItems = builder
+                    .comment("Should items be rendered on pedestal")
+                    .comment("§6§lMEDIUM§f impact when §a§lTRUE")
+                    .comment("§2§lLOWEST§f impact when §c§lFALSE")
+                    .define("Render Items", true);
+            pedestalRenderParticles = builder
+                    .comment("Should pedestals render particles")
+                    .comment("§a§lLOW§f impact when §a§lTRUE")
+                    .comment("§2§lLOWEST§f impact when §c§lFALSE")
+                    .define("Render Particles", true);
+            pedestalRenderHUD = builder
+                    .comment("Should pedestals render HUD elements?")
+                    .comment("§a§lLOW§f impact when §a§lTRUE")
+                    .comment("§2§lLOWEST§f impact when §c§lFALSE")
+                    .define("Render HUD", true);
+            pedestalRenderUpgrades = builder
+                    .comment("Should pedestals render upgrades?")
+                    .comment("This will prevent upgrades from being rendered")
+                    .comment("Set to false if you're experiencing client-side lag from Pedestals")
+                    .comment("§4§lHIGHEST§f impact when §a§lTRUE")
+                    .comment("§2§lLOWEST§f impact when §c§lFALSE")
+                    .define("Render Upgrades", true);
+            pedestalRenderToolSlot = builder
+                    .comment("Should pedestals render their Tool Slot which is located at the TOP?")
+                    .comment("§a§lLOW§f impact when §a§lTRUE")
+                    .comment("§2§lLOWEST§f impact when §c§lFALSE")
+                    .define("Render Tool Slot", true);
+            pedestalRenderUpgradeInToolSlot = builder
+                    .comment("Should the pedestal upgrades be rendered on TOP instead?")
+                    .comment("This will prevent the 'Tool Slot' from being rendered")
+                    .comment("§a§lLOW§f impact when §c§lFALSE")
+                    .comment("§2§lLOWEST§f impact when §a§lTRUE")
+                    .define("Render Upgrades in Tool Slot", false);
+            pedestalRenderDistance = builder
+                    .comment("Distance (blocks) away before Pedestal renders")
+                    .comment("§6§lMEDIUM§f impact when on §c§l64")
+                    .comment("§2§lLOWEST§f impact when on §a§l1")
+                    .defineInRange("Render Distance", 8, 1, 64);
+            builder.pop();
+        }
+    }
+
     public static final ForgeConfigSpec commonSpec;
     public static final Common COMMON;
+    public static final ForgeConfigSpec clientSpec;
+    public static final Client CLIENT;
 
     static {
         final Pair<Common, ForgeConfigSpec> specPair = new ForgeConfigSpec.Builder().configure(Common::new);
         commonSpec = specPair.getRight();
         COMMON = specPair.getLeft();
+
+        final Pair<Client, ForgeConfigSpec> clientSpecPair = new ForgeConfigSpec.Builder().configure(Client::new);
+        clientSpec = clientSpecPair.getRight();
+        CLIENT = clientSpecPair.getLeft();
     }
 
     @SubscribeEvent

--- a/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlockEntity.java
+++ b/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlockEntity.java
@@ -1767,18 +1767,23 @@ public class BasePedestalBlockEntity extends MowLibBaseFilterableBlockEntity
 
     public boolean canSpawnParticles()
     {
-        switch (getRendererType())
-        {
-            case 0: return false;
-            case 1: return true;
-            case 2: return true;
-            case 3: return false;
-            case 4: return false;
-            case 5: return true;
-            case 6: return false;
-            case 7: return true;
-            default: return true;
+        boolean particlesEnabled = PedestalConfig.CLIENT.pedestalRenderParticles.get();
+        if(particlesEnabled) {
+            switch (getRendererType())
+            {
+                case 0: return false;
+                case 1: return true;
+                case 2: return true;
+                case 3: return false;
+                case 4: return false;
+                case 5: return true;
+                case 6: return false;
+                case 7: return true;
+                default: return true;
+            }
         }
+        return false;
+
     }
 
     public int  getRendererType()

--- a/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlockEntityRenderer.java
+++ b/src/main/java/com/mowmaster/pedestals/blocks/Pedestal/BasePedestalBlockEntityRenderer.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
 import com.mowmaster.mowlib.Items.WorkCards.WorkCardArea;
 import com.mowmaster.mowlib.api.DefineLocations.ISelectablePoints;
+import com.mowmaster.pedestals.Configs.PedestalConfig;
 import com.mowmaster.pedestals.Items.Upgrades.Pedestal.ItemUpgradeBase;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
@@ -25,6 +26,8 @@ import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
 import org.joml.AxisAngle4f;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
@@ -37,7 +40,7 @@ import static com.mowmaster.mowlib.MowLibUtils.MowLibBlockPosUtils.*;
 import static com.mowmaster.pedestals.Blocks.Pedestal.BasePedestalBlock.FACING;
 import static com.mowmaster.pedestals.PedestalUtils.References.MODID;
 
-public class BasePedestalBlockEntityRenderer implements BlockEntityRenderer<BasePedestalBlockEntity>
+public class BasePedestalBlockEntityRenderer implements BlockEntityRenderer<com.mowmaster.pedestals.Blocks.Pedestal.BasePedestalBlockEntity>
 {
 
     public BasePedestalBlockEntityRenderer(BlockEntityRendererProvider.Context context) {}
@@ -182,8 +185,6 @@ public class BasePedestalBlockEntityRenderer implements BlockEntityRenderer<Base
                 }
                 if(facing== Direction.DOWN) {
                     //p_112309_.rotate(new Quaternion(0, 0, 1,180));
-
-
                     p_112309_.mulPose(Axis.ZP.rotationDegrees(180));
                     p_112309_.translate(0, -1, 0);
                     p_112309_.translate(-1, 0, 0);
@@ -193,7 +194,6 @@ public class BasePedestalBlockEntityRenderer implements BlockEntityRenderer<Base
                 }
                 if(facing== Direction.NORTH) {
                     //p_112309_.rotate(new Quaternion(1, 0, 0,270));
-
                     p_112309_.mulPose(Axis.XP.rotationDegrees(270));
                     p_112309_.translate(0, -1, 0);
                     renderTileItems(world,p_112309_,p_112310_,listed,coin,toolStack,p_112311_,p_112312_,renderAugmentType,hudMessages);
@@ -227,7 +227,9 @@ public class BasePedestalBlockEntityRenderer implements BlockEntityRenderer<Base
             }
         }
     }
+
     //public static void  renderTile(Level worldIn, PoseStack p_112309_, MultiBufferSource p_112310_, ItemStack coin, ItemStack item, int p_112311_, int p_112312_, int renderAugmentType)
+    /*
     public static void  renderTile(Level worldIn, PoseStack p_112309_, MultiBufferSource p_112310_, ItemStack item, ItemStack coin, int p_112311_, int p_112312_, int renderAugmentType)
     {
         switch (renderAugmentType)
@@ -276,95 +278,66 @@ public class BasePedestalBlockEntityRenderer implements BlockEntityRenderer<Base
 
         }
     }
+     */
 
-    public static void renderItemRotating(Level worldIn, PoseStack p_112309_, MultiBufferSource p_112310_, ItemStack itemStack, int p_112311_, int p_112312_)
-    {
-        if (!itemStack.isEmpty()) {
-            p_112309_.pushPose();
-            p_112309_.translate(0.5, 1.0, 0.5);
-            //p_112309_.translate(0, MathHelper.sin((worldIn.getGameTime()) / 10.0F) * 0.1 + 0.1, 0); BOBBING ITEM
-            p_112309_.scale(0.75F, 0.75F, 0.75F);
+    public static void renderItemsRotating(Level worldIn, PoseStack posStack, MultiBufferSource buffers, List<ItemStack> listed, int light, int overlay) {
+        //https://github.com/VazkiiMods/Botania/blob/1.18.x/Xplat/src/main/java/vazkii/botania/client/render/tile/RenderTileRuneAltar.java#L49
+        if(listed != null && !listed.isEmpty()) {
+            posStack.pushPose();
+            posStack.translate(0.5, 1.0, 0.5);
+            posStack.scale(0.75F, 0.75F, 0.75F);
             long time = System.currentTimeMillis();
-            float angle = (time/25) % 360;
-            //float angle = (worldIn.getGameTime()) / 20.0F * (180F / (float) Math.PI);
-            p_112309_.mulPose(Axis.YP.rotationDegrees(angle));
+            float angle = time / 25 % 360;
+            boolean rotateEnabled = PedestalConfig.CLIENT.pedestalRotateItems.get();
+            if(rotateEnabled) {
+                posStack.mulPose(Axis.YP.rotationDegrees(angle));
+            }
+            ItemStack stack = listed.get(0);
             ItemRenderer renderer = Minecraft.getInstance().getItemRenderer();
-            BakedModel baked = renderer.getModel(itemStack,worldIn,null,0);
-            renderer.render(itemStack, ItemDisplayContext.GROUND,true,p_112309_,p_112310_,p_112311_,p_112312_,baked);
-
-            //Minecraft.getInstance().getItemRenderer().renderItem(itemStack, ItemCameraTransforms.TransformType.GROUND, p_112311_, p_112312_, p_112309_, p_112310_);
-            p_112309_.popPose();
+            BakedModel bakedModel = renderer.getModel(stack, worldIn, null, 0);
+            renderer.render(stack, ItemDisplayContext.GROUND, true, posStack, buffers, light, overlay, bakedModel);
+            posStack.popPose();
         }
     }
 
-    public static void  renderTileItems(Level worldIn, PoseStack p_112309_, MultiBufferSource p_112310_, List<ItemStack> item, ItemStack coin,ItemStack toolStack, int p_112311_, int p_112312_, int renderAugmentType, List<String> messages)
-    {
-        switch (renderAugmentType)
-        {
-            case 0:
-                renderItemsRotating(worldIn,p_112309_,p_112310_,item,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.5f,0.475f,0.3125f,0,0,0,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.3125f,0.475f,0.5f,90,0,1f,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.5f,0.475f,0.6875f,180,0,1f,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.6875f,0.475f,0.5f,270,0,1f,0,p_112311_,p_112312_);
-                renderTool(worldIn,toolStack,p_112309_,p_112310_,p_112311_,p_112312_);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,-0.75F, 2.25F, 0.5F, 180,0);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,1.5F, 2.25F, 0.5F, 180,180);
-                break;
-            case 1:
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.5f,0.475f,0.3125f,0,0,0,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.3125f,0.475f,0.5f,90,0,1f,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.5f,0.475f,0.6875f,180,0,1f,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.6875f,0.475f,0.5f,270,0,1f,0,p_112311_,p_112312_);
-                renderTool(worldIn,toolStack,p_112309_,p_112310_,p_112311_,p_112312_);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,-0.75F, 2.25F, 0.5F, 180,0);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,1.5F, 2.25F, 0.5F, 180,180);
-                break;
-            case 2:
-                renderItemsRotating(worldIn,p_112309_,p_112310_,item,p_112311_,p_112312_);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,-0.75F, 2.25F, 0.5F, 180,0);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,1.5F, 2.25F, 0.5F, 180,180);
-                break;
-            case 3:
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.5f,0.475f,0.3125f,0,0,0,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.3125f,0.475f,0.5f,90,0,1f,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.5f,0.475f,0.6875f,180,0,1f,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.6875f,0.475f,0.5f,270,0,1f,0,p_112311_,p_112312_);
-                renderTool(worldIn,toolStack,p_112309_,p_112310_,p_112311_,p_112312_);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,-0.75F, 2.25F, 0.5F, 180,0);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,1.5F, 2.25F, 0.5F, 180,180);
-                break;
-            case 4:
-                renderItemsRotating(worldIn,p_112309_,p_112310_,item,p_112311_,p_112312_);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,-0.75F, 2.25F, 0.5F, 180,0);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,1.5F, 2.25F, 0.5F, 180,180);
-                break;
-            case 5: break;
-            case 6: break;
-            case 7:
-                renderItemsRotating(worldIn,p_112309_,p_112310_,item,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.5f,0.475f,0.3125f,0,0,0,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.3125f,0.475f,0.5f,90,0,1f,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.5f,0.475f,0.6875f,180,0,1f,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.6875f,0.475f,0.5f,270,0,1f,0,p_112311_,p_112312_);
-                renderTool(worldIn,toolStack,p_112309_,p_112310_,p_112311_,p_112312_);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,-0.75F, 2.25F, 0.5F, 180,0);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,1.5F, 2.25F, 0.5F, 180,180);
-                break;
-            default:
-                renderItemsRotating(worldIn,p_112309_,p_112310_,item,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.5f,0.475f,0.3125f,0,0,0,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.3125f,0.475f,0.5f,90,0,1f,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.5f,0.475f,0.6875f,180,0,1f,0,p_112311_,p_112312_);
-                renderCoin(worldIn,coin,p_112309_,p_112310_,0.6875f,0.475f,0.5f,270,0,1f,0,p_112311_,p_112312_);
-                renderTool(worldIn,toolStack,p_112309_,p_112310_,p_112311_,p_112312_);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,-0.75F, 2.25F, 0.5F, 180,0);
-                if(messages.size()>0)renderPedestalsHUD(p_112309_,p_112310_,messages,1.5F, 2.25F, 0.5F, 180,180);
-                break;
+    public static void renderTileItems(Level worldIn, PoseStack poseStack, MultiBufferSource multiBufferSource, List<ItemStack> item, ItemStack coin, ItemStack toolStack, int p_112311_, int p_112312_, int renderAugmentType, List<String> messages) {
+        boolean renderUpgrades = PedestalConfig.CLIENT.pedestalRenderUpgrades.get();
+        boolean renderUpgradesInToolSlot = PedestalConfig.CLIENT.pedestalRenderUpgradeInToolSlot.get();
+        if(renderUpgradesInToolSlot) {
+            if (renderUpgrades) {
+                renderTool(worldIn, coin, poseStack, multiBufferSource, p_112311_, p_112312_);
+            }
+        } else {
+            if (renderUpgrades) {
+                renderCoin(worldIn, coin, poseStack, multiBufferSource, 0.5f, 0.475f, 0.3125f,0, p_112311_,p_112312_);
+                renderCoin(worldIn, coin, poseStack, multiBufferSource, 0.3125f, 0.475f, 0.5f,90, p_112311_,p_112312_);
+                renderCoin(worldIn, coin, poseStack, multiBufferSource, 0.5f, 0.475f, 0.6875f,180, p_112311_,p_112312_);
+                renderCoin(worldIn, coin, poseStack, multiBufferSource, 0.6875f, 0.475f, 0.5f,270, p_112311_,p_112312_);
+            }
+            boolean renderUpgradeExtras = PedestalConfig.CLIENT.pedestalRenderToolSlot.get();
+            if (renderUpgradeExtras) {
+                renderTool(worldIn, toolStack, poseStack, multiBufferSource, p_112311_, p_112312_);
+            }
+        }
 
+        boolean renderHUD = PedestalConfig.CLIENT.pedestalRenderHUD.get();
+        if (renderHUD) {
+            if (messages.size() > 0) {
+                renderPedestalsHUD(poseStack, multiBufferSource, messages, -0.75F, 2.25F, 0.5F, 180,0);
+                renderPedestalsHUD(poseStack, multiBufferSource, messages, 1.5F, 2.25F, 0.5F, 180,180);
+                //private static void renderPedestalsHUD(PoseStack matrixStack, MultiBufferSource buffer, List<String> messages, float x, float y, float z, int angleX, int angleY) {
+            }
+        }
+
+        boolean renderItems = PedestalConfig.CLIENT.pedestalRenderItems.get();
+        if (renderItems) {
+            if (!(renderAugmentType == 5 || renderAugmentType == 6)) {
+                renderItemsRotating(worldIn, poseStack, multiBufferSource, item, p_112311_, p_112312_);
+            }
         }
     }
 
+/*
     public static void renderItemsRotating(Level worldIn, PoseStack posStack, MultiBufferSource buffers, List<ItemStack> listed, int light, int overlay)
     {
         //https://github.com/VazkiiMods/Botania/blob/1.18.x/Xplat/src/main/java/vazkii/botania/client/render/tile/RenderTileRuneAltar.java#L49
@@ -428,18 +401,27 @@ public class BasePedestalBlockEntityRenderer implements BlockEntityRenderer<Base
             posStack.popPose();
         }
     }
+    */
 
-    public static void renderCoin(Level worldIn,ItemStack itemCoin, PoseStack p_112309_, MultiBufferSource p_112310_, float x, float y, float z, float angle, float xr, float yr, float zr, int p_112311_, int p_112312_) {
+    private static final ItemRenderer itemRenderer = Minecraft.getInstance().getItemRenderer();
+    private static BakedModel cachedModel = null;
+
+    public static void renderCoin(Level worldIn, ItemStack itemCoin, PoseStack poseStack, MultiBufferSource bufferSource, float x, float y, float z, float angle, int overlay, int light) {
         if (!itemCoin.isEmpty()) {
-            p_112309_.pushPose();
-            p_112309_.translate(x, y, z);
-            p_112309_.scale(0.1875f, 0.1875f, 0.1875f);
-            p_112309_.mulPose(Axis.YP.rotationDegrees(angle));
-            ItemRenderer renderer = Minecraft.getInstance().getItemRenderer();
-            BakedModel baked = renderer.getModel(itemCoin,worldIn,null,0);
-            renderer.render(itemCoin,ItemDisplayContext.FIXED,true,p_112309_,p_112310_,p_112311_,p_112312_,baked);
-            //Minecraft.getInstance().getItemRenderer().renderItem(itemCoin, ItemCameraTransforms.TransformType.FIXED, p_112311_, p_112312_, p_112309_, p_112310_);
-            p_112309_.popPose();
+            poseStack.pushPose();
+            poseStack.translate(x, y, z);
+            poseStack.scale(0.1875f, 0.1875f, 0.1875f);
+            poseStack.mulPose(Axis.YP.rotationDegrees(angle));
+
+            // Check if the coin model is already cached
+            if (cachedModel == null || cachedModel != itemRenderer.getModel(itemCoin, worldIn, null, 0)) {
+                cachedModel = itemRenderer.getModel(itemCoin, worldIn, null, 0);
+            }
+
+            // Render the coin using the current pose stack
+            itemRenderer.render(itemCoin, ItemDisplayContext.FIXED, true, poseStack, bufferSource, overlay, light, cachedModel);
+
+            poseStack.popPose();
         }
     }
 
@@ -657,5 +639,12 @@ public class BasePedestalBlockEntityRenderer implements BlockEntityRenderer<Base
         {
             return false;
         }
+    }
+
+    @Override
+    public boolean shouldRender(BasePedestalBlockEntity blockEntity, @NotNull Vec3 playerPos) {
+        Vec3 blockPos = Vec3.atCenterOf(blockEntity.getBlockPos());
+        int renderDistance = PedestalConfig.CLIENT.pedestalRenderDistance.get();
+        return blockPos.closerThan(playerPos, renderDistance); //Only render pedestals in x blocks radius
     }
 }

--- a/src/main/java/com/mowmaster/pedestals/pedestals.java
+++ b/src/main/java/com/mowmaster/pedestals/pedestals.java
@@ -51,6 +51,7 @@ public class pedestals
         IEventBus eventBus = FMLJavaModLoadingContext.get().getModEventBus();
         DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> eventBus.register(new ClientRegistry()));
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, PedestalConfig.commonSpec);
+        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, PedestalConfig.clientSpec);
 
         eventBus.register(PedestalConfig.class);
 


### PR DESCRIPTION
Added client config:

* option to toggle Item Rotation on/off (default on)
* option to toggle Item Rendering on/off (default on)
* option to change Distance away that a pedestal gets rendered (default 8 blocks)
* option to toggle HUD rendering on/off (default on)
* option to toggle Particle rendering on/off (default on)
* option to toggle Upgrade rendering on/off (default on)
* option to toggle Tool Slot rendering on/off (default on)
* option to render Upgrade in Tool Slot instead on/off (default off)